### PR TITLE
Load cartridge

### DIFF
--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -6,6 +6,9 @@ use std::io;
 
 use crate::memory::Memory;
 
+const HEADER_START: usize = 0x100;
+const HEADER_SIZE: usize = 80;
+
 #[derive(Debug)]
 enum CartridgeType {
     RomOnly = 0x00,
@@ -49,6 +52,8 @@ struct Header {
     title: String,
     cart_type: CartridgeType,
     cart_mode: CartridgeMode,
+    rom_size: usize,
+    ram_size: usize,
     header_checksum: u8,
     cart_checksum: u16,
 }
@@ -59,9 +64,19 @@ impl Header {
             title: String::new(),
             cart_type: CartridgeType::RomOnly,
             cart_mode: CartridgeMode::PgbMode,
+            rom_size: 0,
+            ram_size: 0,
             header_checksum: 0,
             cart_checksum: 0,
         }
+    }
+
+    fn dump(&self) {
+        println!("Title: {}", self.title);
+        println!("Type: {:?}", self.cart_type);
+        println!("Mode: {:?}", self.cart_mode);
+        println!("ROM: {}KiB", self.rom_size / 1024);
+        println!("RAM: {}KiB", self.ram_size / 1024);
     }
 }
 
@@ -80,11 +95,17 @@ impl Cartridge {
         }
     }
 
-    pub fn load_rom(&mut self, path: String) -> Result<(),io::Error> {
+    pub fn load_rom(&mut self, path: String) -> Result<(), io::Error> {
         self.rom = fs::read(path)?;
-        self.loaded = true;
+        if self.rom.len() < (HEADER_START + HEADER_SIZE) {
+            panic!("missing header");
+        }
 
         self.parse_header();
+        self.loaded = true;
+
+        #[cfg(debug_assertions)]
+        self.header.dump();
 
         Ok(())
     }
@@ -111,6 +132,70 @@ impl Cartridge {
             self.header.cart_mode = CartridgeMode::CgbSupported;
         } else {
             self.header.cart_mode = CartridgeMode::PgbMode;
+        }
+
+       self.header.cart_type = match self.mem_read_byte(0x147) {
+            0x00 => CartridgeType::RomOnly,
+            0x01 => CartridgeType::Mbc1,
+            0x02 => CartridgeType::Mbc1Ram,
+            0x03 => CartridgeType::Mbc1RamBattery,
+            0x05 => CartridgeType::Mbc2,
+            0x06 => CartridgeType::Mbc2Battery,
+            0x08 => CartridgeType::RomRam,
+            0x09 => CartridgeType::RomRamBattery,
+            0x0b => CartridgeType::Mmm01,
+            0x0c => CartridgeType::Mmm01Ram,
+            0x0d => CartridgeType::Mmm01RamBattery,
+            0x0f => CartridgeType::Mbc3TimerBattery,
+            0x10 => CartridgeType::Mbc3TimerRamBattery,
+            0x11 => CartridgeType::Mbc3,
+            0x12 => CartridgeType::Mbc3Ram,
+            0x13 => CartridgeType::Mbc3RamBattery,
+            0x19 => CartridgeType::Mbc5,
+            0x1a => CartridgeType::Mbc5Ram,
+            0x1b => CartridgeType::Mbc5RamBattery,
+            0x1c => CartridgeType::Mbc5Rumble,
+            0x1d => CartridgeType::Mbc5RumbleRam,
+            0x1e => CartridgeType::Mbc5RumbleRamBattery,
+            0x20 => CartridgeType::Mbc6,
+            0x22 => CartridgeType::Mbc7SensorRumbleRamBattery,
+            0xfc => CartridgeType::PocketCamera,
+            0xfd => CartridgeType::BandaiTama5,
+            0xfe => CartridgeType::HuC3,
+            0xff => CartridgeType::HuC1RamBattery,
+            _ => panic!("invalid cartridge type"),
+        };
+
+        let rom_size_code = self.mem_read_byte(0x148);
+
+        /*
+         * only support 0x00-0x08
+         * https://gbdev.io/pandocs/The_Cartridge_Header.html#0148---rom-size
+         *
+         * "[0x52-54 are] only listed in unofficial docs. No cartridges or ROM files using these sizes are known.
+         * As the other ROM sizes are all powers of 2, these are likely inaccurate. The source for
+         * these values is unknown."
+         */
+        if rom_size_code > 0x08 {
+            panic!("invalid ROM size");
+        }
+        self.header.rom_size = 32768 << rom_size_code;
+
+        self.header.ram_size = match self.mem_read_byte(0x149) {
+            0x00 => 0, // no RAM
+            0x02 => 8192, // 8KiB
+            0x03 => 32768, // 32KiB
+            0x04 => 131072, // 128KiB
+            0x05 => 65536, // 64KiB
+            _ => panic!("invalid RAM size"),
+        };
+
+        // When using a MBC2 chip, 0x00 must be specified as the RAM Size, even though the MBC2
+        // includes a built-in RAM of 512 x 4 bits.
+        if (matches!(self.header.cart_type, CartridgeType::Mbc2)
+            || matches!(self.header.cart_type, CartridgeType::Mbc2Battery))
+           && self.header.ram_size != 0 {
+            panic!("RAM size must be 0 when using MBC2 chip");
         }
     }
 

--- a/src/gameboy/mod.rs
+++ b/src/gameboy/mod.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
+use std::io;
 use std::rc::Rc;
 use std::time::Duration;
 use std::thread::sleep;
@@ -45,7 +46,10 @@ impl Gameboy {
     }
 
 
-    pub fn run(&mut self) -> Result<(), String> {
+    pub fn run(&mut self, rom: String) -> Result<(), io::Error> {
+
+        self.mmu.borrow_mut().cartridge.load_rom(rom)?;
+
         'running: loop {
             self.handle_sdl2_events()?;
             sleep(Duration::from_millis(100));
@@ -54,8 +58,8 @@ impl Gameboy {
         Ok(())
     }
 
-    fn handle_sdl2_events(&mut self) -> Result<(), String> {
-        let mut event_pump = self.sdl_context.event_pump()?;
+    fn handle_sdl2_events(&mut self) -> Result<(), io::Error> {
+        let mut event_pump = self.sdl_context.event_pump().unwrap();
         for event in event_pump.poll_iter() {
             match event {
                 Event::Quit {..}
@@ -63,7 +67,7 @@ impl Gameboy {
                     keycode: Some(Keycode::Escape),
                     repeat: false,
                     ..
-                } => return Err("quit requested".to_string()),
+                } => return Err(io::Error::from_raw_os_error(0)),
                 Event::KeyDown { keycode: Some(Keycode::A), repeat: false, .. } => {
                     self.mmu.borrow_mut().joypad.left = true;
                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,14 +5,35 @@ mod joypad;
 mod memory;
 mod mmu;
 
+use std::env;
+use std::io;
+
 use crate::gameboy::Gameboy;
 
 const WIDTH: u32 = 800;
 const HEIGHT: u32 = 600;
 
-fn main() -> Result<(), String> {
-    let mut gameboy = Gameboy::init(WIDTH, HEIGHT)?;
-    gameboy.run()?;
+fn print_usage() {
+    println!("usage: dookieboy rom_path");
+    println!("  rom_path: absolute or relative path to ROM file");
+}
 
-    Ok(())
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        print_usage();
+        std::process::exit(1);
+    }
+
+    let rom = String::from(&args[1]);
+
+    let mut gameboy = Gameboy::init(WIDTH, HEIGHT).unwrap();
+    match gameboy.run(rom) {
+        Ok(v) => {},
+        Err(e) => {
+            println!("dookieboy encountered big error: {}\n", e);
+            print_usage();
+            std::process::exit(1);
+        },
+    }
 }

--- a/src/mmu/mod.rs
+++ b/src/mmu/mod.rs
@@ -1,5 +1,6 @@
 // src/mmu.rs
 
+use crate::cartridge::Cartridge;
 use crate::joypad::Joypad;
 use crate::memory::Memory;
 
@@ -21,6 +22,7 @@ use crate::memory::Memory;
  */
 
 pub struct Mmu {
+    pub cartridge: Cartridge,
     pub joypad: Joypad,
 
 }
@@ -28,6 +30,7 @@ pub struct Mmu {
 impl Memory for Mmu {
     fn mem_read_byte(&self, addr: u16) -> u8 {
         match addr {
+            0x0000..=0x7fff => self.cartridge.mem_read_byte(addr),
             0xff00 => self.joypad.mem_read_byte(addr),
             _ => panic!("not valid address"),
         }
@@ -35,6 +38,7 @@ impl Memory for Mmu {
 
     fn mem_write_byte(&mut self, addr: u16, val: u8) {
         match addr {
+            0x0000..=0x7fff => self.cartridge.mem_write_byte(addr, val),
             0xff00 => self.joypad.mem_write_byte(addr, val),
             _ => panic!("not valid address"),
         }
@@ -44,6 +48,7 @@ impl Memory for Mmu {
 impl Mmu {
     pub fn new() -> Mmu {
         Mmu {
+            cartridge: Cartridge::new(),
             joypad: Joypad::new(),
         }
     }


### PR DESCRIPTION
- fully parse cartridge header (well, as much as we need to)
- take ROM path as argument
- load ROM file into host RAM
- dump ROM information on debug builds